### PR TITLE
Update build workflow to publish mkdocs straight to deployment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,25 +1,48 @@
 name: publish
+
 on:
+  workflow_dispatch: # allow manual runs
   push:
     branches:
       - main
-  workflow_dispatch:
+
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false # skip any intermediate builds but let finish
+
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.11
+      - id: pages
+        uses: actions/configure-pages@v4
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           restore-keys: |
             mkdocs-material-
       - run: pip install -r requirements.txt
-      - run: mkdocs gh-deploy --force
+      - run: mkdocs build -d site
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This moves the whole build and deploy from force-pushing a git history into actions workflow, skipping committing to `gh-pages` branch (that could eventually be removed), and publishing to the deployment environment directly.

Only caveat is publishing from `mkdocs gh-deploy` CLI locally won't work, but I see it being removed from readme now so it's probably discouraged from anyways, to deploy only with GHA via `main`. This kinda makes it the only path;)

_(Usually needs manual switch in repo Settings from branch deploy to action deploy to work, otherwise the env is protected from the classic runs…)_

See the GHA log for this workflow [‹b87a0eb› here](https://github.com/janbrasna/birdbox-documentation/actions/runs/8723483593/job/23931811422#step:8:1)