### PR TITLE
Fix FAQ relative links

### DIFF
--- a/docs/bootstrapping.md
+++ b/docs/bootstrapping.md
@@ -71,7 +71,7 @@ As part of the infrastructure setup (above), new configuration files will have b
 !!! note
     A developer will need appropriate access to the `mozilla-it` organisation.
 
-    Commits made to webservices-infra [need to be signed](../faqs/#how-do-i-sign-commits) in order to be merged.
+    Commits made to webservices-infra [need to be signed](faqs.md#how-do-i-sign-commits) in order to be merged.
 
 In that repo you will find a folder for your project - e.g. `birdbox-newsite` or just `newsite`.
 
@@ -155,7 +155,7 @@ SSO is managed by the IAM team, and you can request setup via JIRA
 
 Once that request is done, there are three steps left:
 
-1. Get the OIDC credentials into the relevant environments - explained [here](../faqs/#how-do-i-edit-secrets)
+1. Get the OIDC credentials into the relevant environments - explained [here](faqs.md#how-do-i-edit-secrets)
 2. Bootstrap an admin user for yourself - this is covered below
 
 !!! note "Don't forget"
@@ -172,7 +172,7 @@ Now comes the stage where you can start adding pages and content into the site, 
 
     If you have Dev, Stage and Prod sites and you want them all to have similar content, you'll need to set them all up the same way.
 
-    You can either duplicate the same manual effort across all three, or add content to one of them and then copy it to the other two. That copying process is currently pretty hands-on, but there are [some tips here](../faqs/#how-to-i-copy-data-between-devstageprod-sites).
+    You can either duplicate the same manual effort across all three, or add content to one of them and then copy it to the other two. That copying process is currently pretty hands-on, but there are [some tips here](faqs.md#how-to-i-copy-data-between-devstageprod-sites).
 
 ### Add an initial admin user
 
@@ -180,7 +180,7 @@ The system starts with no users, and you can't log in to create users unless a m
 
 On each deployed environment - dev, stage and prod, do this:
 
-1) Shell into a running pod - [see here if you need help](../faqs/#how-do-i-shell-into-a-running-pod)
+1) Shell into a running pod - [see here if you need help](faqs.md#how-do-i-shell-into-a-running-pod)
 
 2) Run `python birdbox/manage.py createsuperuser --email=YOURIDENTITY@mozilla.com --username=YOURIDENTITY@mozilla.com --no-input`. It is crucial that `YOURIDENTITY@mozilla.com` matches your Mozilla SSO email address.
 
@@ -209,7 +209,7 @@ Wagtail comes pre-set-up with a default "Welcome to your Wagtail site!" page at 
 
 The footer can be manually edited via `Settings > Configure footer`, where links are grouped into columns and the small links are handled as rich text.
 
-If you want to quickly add a Mozilla.org-like footer to a site, you can [shell into a pod](../faqs/#how-do-i-shell-into-a-running-pod) for the relevant environment and run: `python birdbox/manage.py bootstrap_footer --commit`
+If you want to quickly add a Mozilla.org-like footer to a site, you can [shell into a pod](faqs.md#how-do-i-shell-into-a-running-pod) for the relevant environment and run: `python birdbox/manage.py bootstrap_footer --commit`
 
 #### Nav
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -53,7 +53,7 @@ Future improvements to explore:
 2. Add a new HTML template fragment for the new block in `microsite/templates/blocks/`
     * Base the markup on the HTML in the Protocol docs' examples
     * Remember to circle back and reference the template filename in the Python block definition - see other blocks for examples
-3. If JS or CSS is needed for the component, configure webpack to build it - see `src/css/protocol/card.scss` as an example or [this FAQ](../faqs/#how-do-i-add-css-or-js-to-the-project).
+3. If JS or CSS is needed for the component, configure webpack to build it - see `src/css/protocol/card.scss` as an example or [this FAQ](faqs.md#how-do-i-add-css-or-js-to-the-project).
     * Remember to circle back to the Python nlock definition to set the `frontend_media` property so that this CSS/JS gets included on page load
 4. Find the page (in `microsite.models`) with a `StreamField` that you want the new component to be available in. Add it to the list of blocks that are available.
 5. `just makemigrations` then `just migrate` to udpate the database.

--- a/docs/faqs.md
+++ b/docs/faqs.md
@@ -97,10 +97,10 @@ To add a new CSS or JS file:
 
 ### How do I configure the nav for a site?
 
-See [here](../bootstrapping/#enable-footer-and-nav).
+See [here](bootstrapping.md#enable-footer-and-nav).
 
 ### How do I edit the footer for site?
 
-See [here](../bootstrapping/#enable-footer-and-nav).
+See [here](bootstrapping.md#enable-footer-and-nav).
 
 [^1]: This trigger branch refers to the `main` branch of the pipeline code in `deploy-newsite`, not the `birdbox-newsite` application codebase.

--- a/docs/local_development.md
+++ b/docs/local_development.md
@@ -21,7 +21,7 @@ This mode uses sqlite for the DB and stores uploaded media on your machine.
 * To make an admin user `just createsuperuser`. If there are no SSO credentials in your local environment or `.env` file, Birdbox falls back to standard username-plus-password auth.
 * To run the local webpack bundler + django runserver: `just run-local` or `npm start` (both do the same thing)
 * Go to <http://localhost:8000> for the default Wagtail site, and <http://localhost:8000/admin/> for the CMS UI
-* Ideally you would now load in an export from another developer (see tips below), or you can bootstrao your own local site using [the same steps for a live site](../bootstrapping/#wagtail-bootstrap-an-initial-site).
+* Ideally you would now load in an export from another developer (see tips below), or you can bootstrao your own local site using [the same steps for a live site](bootstrapping.md#wagtail-bootstrap-an-initial-site).
 
 ## Running via Docker on your machine
 


### PR DESCRIPTION
Has no impact for prod docs, the output paths worked before in built sites.

Only fixes relative linking to:
1. allow local md file links work and be valid, also enabling navigation via gh repo ui,
2. silence build warnings,
3. (test the new gha deployment too;)