### PR TITLE
Update publish workflow caching

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,15 +23,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11
+          cache: pip
       - id: pages
-        uses: actions/configure-pages@v4
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: .cache
-          restore-keys: |
-            mkdocs-material-
+        uses: actions/configure-pages@v5
       - run: pip install -r requirements.txt
       - run: mkdocs build -d site
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This is the preferred way to store built wheels and package downloads for some time.

Refs: https://github.com/mozmeao/birdbox-documentation/pull/14#pullrequestreview-2006268423

Also bumps configure-pages action _(fixes vague error reporting etc.)_